### PR TITLE
Implement background task queue with worker service

### DIFF
--- a/background-job/queued-background-task/BackgroundTaskQueue.cs
+++ b/background-job/queued-background-task/BackgroundTaskQueue.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Channels;
+
+namespace queued_background_task;
+public class BackgroundTaskQueue : IBackgroundTaskQueue
+{
+    private readonly Channel<Func<CancellationToken, ValueTask>> _queue;
+
+    public BackgroundTaskQueue(int capacity)
+    {
+        // Capacity should be set based on the expected application load and
+        // number of concurrent threads accessing the queue.            
+        // BoundedChannelFullMode.Wait will cause calls to WriteAsync() to return a task,
+        // which completes only when space became available. This leads to backpressure,
+        // in case too many publishers/calls start accumulating.
+        var options = new BoundedChannelOptions(capacity)
+        {
+            FullMode = BoundedChannelFullMode.Wait
+        };
+        _queue = Channel.CreateBounded<Func<CancellationToken, ValueTask>>(options);
+    }
+
+    public async ValueTask QueueBackgroundWorkItemAsync(Func<CancellationToken, ValueTask> workItem)
+    {
+        ArgumentNullException.ThrowIfNull(workItem);
+
+        await _queue.Writer.WriteAsync(workItem);
+    }
+
+    public async ValueTask<Func<CancellationToken, ValueTask>> DequeueAsync(CancellationToken cancellationToken)
+    {
+        var workItem = await _queue.Reader.ReadAsync(cancellationToken);
+
+        return workItem;
+    }
+}

--- a/background-job/queued-background-task/IBackgroundTaskQueue.cs
+++ b/background-job/queued-background-task/IBackgroundTaskQueue.cs
@@ -1,0 +1,7 @@
+﻿namespace queued_background_task;
+public interface IBackgroundTaskQueue
+{
+    ValueTask QueueBackgroundWorkItemAsync(Func<CancellationToken, ValueTask> workItem);
+
+    ValueTask<Func<CancellationToken, ValueTask>> DequeueAsync(CancellationToken cancellationToken);
+}

--- a/background-job/queued-background-task/MonitorLoop.cs
+++ b/background-job/queued-background-task/MonitorLoop.cs
@@ -1,0 +1,75 @@
+﻿namespace queued_background_task;
+public class MonitorLoop
+{
+    private readonly IBackgroundTaskQueue _taskQueue;
+    private readonly ILogger _logger;
+    private readonly CancellationToken _cancellationToken;
+
+    public MonitorLoop(IBackgroundTaskQueue taskQueue,
+        ILogger<MonitorLoop> logger,
+        IHostApplicationLifetime applicationLifetime)
+    {
+        _taskQueue = taskQueue;
+        _logger = logger;
+        _cancellationToken = applicationLifetime.ApplicationStopping;
+    }
+
+    public void StartMonitorLoop()
+    {
+        _logger.LogInformation("MonitorAsync Loop is starting.");
+
+        // Run a console user input loop in a background thread
+        Task.Run(async () => await MonitorAsync());
+    }
+
+    private async ValueTask MonitorAsync()
+    {
+        while (!_cancellationToken.IsCancellationRequested)
+        {
+            var keyStroke = Console.ReadKey();
+
+            if (keyStroke.Key == ConsoleKey.W)
+            {
+                // Enqueue a background work item
+                await _taskQueue.QueueBackgroundWorkItemAsync(BuildWorkItem);
+            }
+        }
+    }
+
+    private async ValueTask BuildWorkItem(CancellationToken token)
+    {
+        // Simulate three 5-second tasks to complete
+        // for each enqueued work item
+
+        int delayLoop = 0;
+        var guid = Guid.NewGuid().ToString();
+
+        _logger.LogInformation("Queued Background Task {Guid} is starting.", guid);
+
+        while (!token.IsCancellationRequested && delayLoop < 3)
+        {
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5), token);
+            }
+            catch (OperationCanceledException)
+            {
+                // Prevent throwing if the Delay is cancelled
+            }
+
+            delayLoop++;
+
+            _logger.LogInformation("Queued Background Task {Guid} is running. "
+                                   + "{DelayLoop}/3", guid, delayLoop);
+        }
+
+        if (delayLoop == 3)
+        {
+            _logger.LogInformation("Queued Background Task {Guid} is complete.", guid);
+        }
+        else
+        {
+            _logger.LogInformation("Queued Background Task {Guid} was cancelled.", guid);
+        }
+    }
+}

--- a/background-job/queued-background-task/Program.cs
+++ b/background-job/queued-background-task/Program.cs
@@ -1,0 +1,18 @@
+using queued_background_task;
+
+var builder = Host.CreateApplicationBuilder(args);
+
+builder.Services.AddSingleton<MonitorLoop>();
+builder.Services.AddHostedService<QueuedHostedService>();
+builder.Services.AddSingleton<IBackgroundTaskQueue>(ctx =>
+{
+    if (!int.TryParse(builder.Configuration["QueueCapacity"], out var queueCapacity))
+        queueCapacity = 100;
+    return new BackgroundTaskQueue(queueCapacity);
+});
+
+
+var host = builder.Build();
+var monitorLoop = host.Services.GetRequiredService<MonitorLoop>();
+monitorLoop.StartMonitorLoop();
+host.Run();

--- a/background-job/queued-background-task/Properties/launchSettings.json
+++ b/background-job/queued-background-task/Properties/launchSettings.json
@@ -1,0 +1,12 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "queued_background_task": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "environmentVariables": {
+        "DOTNET_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/background-job/queued-background-task/QueuedHostedService.cs
+++ b/background-job/queued-background-task/QueuedHostedService.cs
@@ -1,0 +1,48 @@
+﻿namespace queued_background_task;
+public class QueuedHostedService : BackgroundService
+{
+    private readonly ILogger<QueuedHostedService> _logger;
+
+    public QueuedHostedService(IBackgroundTaskQueue taskQueue, ILogger<QueuedHostedService> logger)
+    {
+        TaskQueue = taskQueue;
+        _logger = logger;
+    }
+
+    public IBackgroundTaskQueue TaskQueue { get; }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            $"Queued Hosted Service is running.{Environment.NewLine}" +
+            $"{Environment.NewLine}Tap W to add a work item to the " +
+            $"background queue.{Environment.NewLine}");
+
+        await BackgroundProcessing(stoppingToken);
+    }
+
+    private async Task BackgroundProcessing(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var workItem = await TaskQueue.DequeueAsync(stoppingToken);
+
+            try
+            {
+                await workItem(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "Error occurred executing {WorkItem}.", nameof(workItem));
+            }
+        }
+    }
+
+    public override async Task StopAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Queued Hosted Service is stopping.");
+
+        await base.StopAsync(stoppingToken);
+    }
+}

--- a/background-job/queued-background-task/README.md
+++ b/background-job/queued-background-task/README.md
@@ -1,0 +1,44 @@
+# Queued Background Task Worker Service
+
+This project demonstrates a .NET Worker Service for managing and executing background tasks using a queue-based approach. It is built with .NET 9 and C# 13.0.
+
+## Components
+
+### 1. IBackgroundTaskQueue
+`IBackgroundTaskQueue` is an interface that defines a contract for queuing and dequeuing background work items:
+- `QueueBackgroundWorkItemAsync(Func<CancellationToken, ValueTask> workItem)`: Enqueues a background task.
+- `DequeueAsync(CancellationToken cancellationToken)`: Dequeues the next background task for execution.
+
+### 2. MonitorLoop
+`MonitorLoop` is a class that monitors console input and enqueues background tasks when the user presses the `W` key. It uses the `IBackgroundTaskQueue` to add work items and logs the progress of each task.
+
+### 3. QueuedHostedService
+`QueuedHostedService` is a `BackgroundService` that continuously dequeues and executes background tasks from the queue. It logs the status and handles exceptions during task execution.
+
+## Architecture Diagram
+
+```mermaid
+flowchart TD
+    subgraph Worker Service
+        ML[MonitorLoop]
+        QHS[QueuedHostedService]
+    end
+    IBTQ[IBackgroundTaskQueue]
+    ML -- Enqueue Work Item --> IBTQ
+    QHS -- Dequeue & Execute Work Item --> IBTQ
+```
+
+- **MonitorLoop**: Listens for user input and enqueues tasks.
+- **QueuedHostedService**: Runs in the background, dequeues, and executes tasks.
+- **IBackgroundTaskQueue**: Manages the queue of background tasks.
+
+## Usage Example
+1. Run the service.
+2. Press `W` in the console to enqueue a background task.
+3. The task will be processed by `QueuedHostedService` and progress will be logged.
+
+---
+For more details, see the source files:
+- `IBackgroundTaskQueue.cs`
+- `MonitorLoop.cs`
+- `QueuedHostedService.cs`

--- a/background-job/queued-background-task/appsettings.Development.json
+++ b/background-job/queued-background-task/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/background-job/queued-background-task/appsettings.json
+++ b/background-job/queued-background-task/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/background-job/queued-background-task/queued-background-task.csproj
+++ b/background-job/queued-background-task/queued-background-task.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>dotnet-queued_background_task-9ab883e6-90a2-4f2e-b8c4-60ccee897913</UserSecretsId>
+    <RootNamespace>queued_background_task</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.7" />
+  </ItemGroup>
+</Project>

--- a/background-job/queued-background-task/queued-background-task.sln
+++ b/background-job/queued-background-task/queued-background-task.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "queued-background-task", "queued-background-task.csproj", "{D8985E3C-F8C0-4481-A414-5E8738760BC4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D8985E3C-F8C0-4481-A414-5E8738760BC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8985E3C-F8C0-4481-A414-5E8738760BC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8985E3C-F8C0-4481-A414-5E8738760BC4}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D8985E3C-F8C0-4481-A414-5E8738760BC4}.Debug|x64.Build.0 = Debug|Any CPU
+		{D8985E3C-F8C0-4481-A414-5E8738760BC4}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D8985E3C-F8C0-4481-A414-5E8738760BC4}.Debug|x86.Build.0 = Debug|Any CPU
+		{D8985E3C-F8C0-4481-A414-5E8738760BC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8985E3C-F8C0-4481-A414-5E8738760BC4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8985E3C-F8C0-4481-A414-5E8738760BC4}.Release|x64.ActiveCfg = Release|Any CPU
+		{D8985E3C-F8C0-4481-A414-5E8738760BC4}.Release|x64.Build.0 = Release|Any CPU
+		{D8985E3C-F8C0-4481-A414-5E8738760BC4}.Release|x86.ActiveCfg = Release|Any CPU
+		{D8985E3C-F8C0-4481-A414-5E8738760BC4}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Implement background task queue with worker service

Updated project to include a background task queue using a worker service architecture. Added logging configuration in `appsettings.json` and `appsettings.Development.json`. Created `IBackgroundTaskQueue` interface and implemented it in `BackgroundTaskQueue` using a bounded channel. Introduced `MonitorLoop` for user input to enqueue tasks and `QueuedHostedService` for background task processing. Updated project structure with a new `.csproj` file, solution file, and added documentation in `README.md`. Included `launchSettings.json` for development environment configuration.